### PR TITLE
Add data formatter for seq2seq-based models

### DIFF
--- a/histocc/__init__.py
+++ b/histocc/__init__.py
@@ -7,3 +7,4 @@ from .model_assets import (
     )
 from .trainer import trainer_loop
 from .dataloader import load_data
+from . import formatter

--- a/histocc/formatter/__init__.py
+++ b/histocc/formatter/__init__.py
@@ -1,0 +1,2 @@
+from .constants import UNK_IDX, PAD_IDX, BOS_IDX, EOS_IDX, SEP_IDX
+from .hisco import format_hisco, clean_hisco, format_hisco_seq, clean_hisco_seq

--- a/histocc/formatter/__init__.py
+++ b/histocc/formatter/__init__.py
@@ -1,2 +1,5 @@
 from .constants import UNK_IDX, PAD_IDX, BOS_IDX, EOS_IDX, SEP_IDX
-from .hisco import format_hisco, clean_hisco, format_hisco_seq, clean_hisco_seq
+from .hisco import (
+    BlockyHISCOFormatter,
+    blocky5,
+    )

--- a/histocc/formatter/__init__.py
+++ b/histocc/formatter/__init__.py
@@ -1,5 +1,7 @@
 from .constants import UNK_IDX, PAD_IDX, BOS_IDX, EOS_IDX, SEP_IDX
 from .hisco import (
+    MAP_HISCO_IDX,
+    MAP_IDX_HISCO,
     BlockyHISCOFormatter,
     blocky5,
     )

--- a/histocc/formatter/constants.py
+++ b/histocc/formatter/constants.py
@@ -1,0 +1,6 @@
+# Define special symbols and indices used in seq2seq models.
+# NOTE: Not all models use these indexes; they are meant for use in seq2seq
+# models and cannot in general be relied upon, as many other models, such as
+# multi-head models, do not use this convention and indeed often have no notion
+# of unknown, padding, BoSs, EoSs, or seperators.
+UNK_IDX, PAD_IDX, BOS_IDX, EOS_IDX, SEP_IDX = 0, 1, 2, 3, 4

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -12,7 +12,7 @@ from typing import Callable
 import numpy as np
 import pandas as pd
 
-from histocc import DATASETS
+from ..datasets import DATASETS
 
 from .constants import PAD_IDX, BOS_IDX, EOS_IDX, SEP_IDX
 

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -192,7 +192,7 @@ def clean_hisco_seq_blocky(
     return clean
 
 
-class HISCOFormatter:
+class BlockyHISCOFormatter: # TODO consider implementing base formatter class
     # Pre-initialization declaration to show guaranteed attribute existence
     format_seq: Callable = None
     clean_seq: Callable = None
@@ -254,3 +254,15 @@ class HISCOFormatter:
         clean = self.clean_seq(raw_pred)
 
         return clean
+
+
+# TODO consider implementing register
+def blocky5() -> BlockyHISCOFormatter:
+    formatter = BlockyHISCOFormatter(
+        max_num_codes=5,
+        map_char_idx=MAP_HISCO_IDX,
+        map_idx_char=MAP_IDX_HISCO,
+        sep_value='&',
+    )
+
+    return formatter

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -54,7 +54,7 @@ def format_hisco(
 
 
 def clean_hisco(
-        formatted_hisco: list[int],
+        formatted_hisco: list[int] | np.ndarray,
         rev_mapping: dict[int, str],
         ) -> str:
     if formatted_hisco[0] in _HISCO_SPECIAL_VALS:
@@ -201,9 +201,9 @@ def clean_hisco_seq_blocky(
 
 class BlockyHISCOFormatter: # TODO consider implementing base formatter class
     # Pre-initialization declaration to show guaranteed attribute existence
-    format_seq: Callable = None
-    clean_seq: Callable = None
-    lookup_hisco: dict[int, int] = None
+    format_seq: Callable
+    clean_seq: Callable
+    lookup_hisco: dict[int, int]
 
     def __init__(
             self,
@@ -275,7 +275,7 @@ class BlockyHISCOFormatter: # TODO consider implementing base formatter class
         return self._max_seq_len
 
     @property
-    def num_classes(self) -> int:
+    def num_classes(self) -> list[int]:
         return [max(self.map_idx_char) + 1] * self._max_seq_len
 
     def transform_label(self, raw_input: str | pd.DataFrame) -> np.ndarray | None:

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -1,0 +1,112 @@
+'''
+Formatter for seq2seq-based HISCO systems
+
+'''
+
+
+import numpy as np
+
+from .constants import UNK_IDX, PAD_IDX, BOS_IDX, EOS_IDX, SEP_IDX
+
+
+MAP_HISCO_IDX = {
+    str(hisco_char): hisco_char + SEP_IDX + 4 for hisco_char in range(-3, 10)
+}
+MAP_IDX_HISCO = {value: key for key, value in MAP_HISCO_IDX.items()}
+
+
+def format_hisco(raw_hisco: str, mapping: dict[str, int]) -> list[int]:
+    if raw_hisco in mapping:
+        # Occurs only for -1, -2, and -3 cases
+        return [mapping[raw_hisco]]
+
+    # Unless in -1, -2, or -3 special case, code should be 5 chars
+    assert len(raw_hisco) == 5, raw_hisco
+
+    label = []
+
+    for char in raw_hisco:
+        label.append(mapping[char])
+
+    return label
+
+
+def clean_hisco(formatted_hisco: list[int], rev_mapping: dict[int, str]) -> str:
+    if len(formatted_hisco) == 1:
+        # Occurs only for -1, -2, and -3 cases
+
+        return rev_mapping[formatted_hisco[0]]
+
+    # Unless in -1, -2, or -3 special case, code should be 5 chars
+    assert len(formatted_hisco) == 5, formatted_hisco
+
+    cleaned = []
+
+    for idx in formatted_hisco:
+        cleaned.append(rev_mapping[idx])
+
+    return ''.join(cleaned)
+
+
+def format_hisco_seq(
+        raw_seq: str,
+        max_num_codes: int,
+        mapping: dict[str, int],
+        sep_value: str = '',
+) -> np.ndarray:
+    if sep_value == '':
+        seq = [raw_seq]
+    else:
+        seq = raw_seq.split(sep_value)
+
+    label = [BOS_IDX]
+
+    for hisco_code in seq:
+        label.extend(format_hisco(hisco_code, mapping))
+        label.append(SEP_IDX)
+
+    # Right now there is an SEP_IDX after last word, replace with EOS_IDX
+    label[-1] = EOS_IDX
+
+    # Now pad to uniform length (+ 2 due to BOS and EOS)
+    padding = 5 * max_num_codes + 2 - len(label)
+    label.extend([PAD_IDX] * padding)
+
+    label = np.array(label)
+
+    # TODO consider adding a cycle consistency check here
+
+    return label.astype('float')
+
+
+def clean_hisco_seq(
+        raw_pred: np.ndarray,
+        sep_value: str = '',
+) -> str:
+    # Strip all BOS tokens
+    pred = raw_pred[raw_pred != BOS_IDX]
+
+    # End at first EOS token
+    if EOS_IDX in pred:
+        first_eos = np.where(pred == EOS_IDX)[0][0]
+    else:
+        first_eos = -1
+
+    pred = pred[:first_eos]
+
+    # Loop over all sub-sequences as defined by SEP_IDX
+    start_idx = 0
+
+    chunks = []
+
+    for idx_sep in np.where(pred == SEP_IDX)[0]:
+        chunks.append(clean_hisco(pred[start_idx:idx_sep]))
+        start_idx = idx_sep + 1
+
+    chunks.append(clean_hisco(pred[start_idx:]))
+
+    clean = sep_value.join(chunks)
+
+    # TODO consider adding cycle consistency check
+
+    return clean

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -186,7 +186,7 @@ def clean_hisco_seq_blocky(
         chunk = raw_pred[start_idx:end_idx]
 
         if chunk[0] == PAD_IDX:
-            chunks.append('')
+            pass
         else:
             chunks.append(clean_hisco(chunk, rev_mapping))
 
@@ -251,11 +251,12 @@ class BlockyHISCOFormatter: # TODO consider implementing base formatter class
 
         for i in range(1, self.max_num_codes + 1):
             code = raw_input[f'code{i}'].item()
-            hisco = self.lookup_hisco[code]
 
-            if math.isnan(hisco):
+            if code is None or math.isnan(code):
+                # If hit NaN, assume subsequent values are also NaN
                 break
 
+            hisco = self.lookup_hisco[code]
             hisco = str(hisco)
 
             if len(hisco) == 4:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from histocc.formatter import blocky5
+
+
+class TestBlockyHISCOFormatter(unittest.TestCase):
+    def setUp(self):
+        self.formatter = blocky5()
+
+    def test_transform_label_string_input(self):
+        raw_input = '12345&-1'
+        expected_output = np.array([
+            2., 9., 10., 11., 12., 13., 7., 7., 7., 7., 7., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 3.,
+            ])
+
+        result = self.formatter.transform_label(raw_input)
+
+        np.testing.assert_array_equal(result, expected_output)
+
+    def test_transform_label_dataframe_input(self):
+        data = {'code1': [123], 'code2': [0], 'code3': [2], 'code4': [None], 'code5': [None]}
+        raw_input = pd.DataFrame(data)
+
+        expected_output = np.array([
+            2.,  8., 11., 13., 13.,  8.,  5.,  5.,  5.,  5.,  5.,  7.,  7., 7.,  7.,  7.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1., 3.,
+            ])
+
+        result = self.formatter.transform_label(raw_input)
+
+        np.testing.assert_array_equal(result, expected_output)
+
+    def test_transform_label_none_input(self):
+        raw_input = None
+        result = self.formatter.transform_label(raw_input)
+        self.assertIsNone(result)
+
+    # We currently do not support empty strings, but perhaps we should
+    # def test_transform_label_empty_string_input(self):
+    #     raw_input = ''
+    #     expected_output = np.array([2., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 3.])
+
+    #     result = self.formatter.transform_label(raw_input)
+
+    #     np.testing.assert_array_equal(result, expected_output)
+
+    def test_clean_pred_valid_input(self):
+        raw_pred = np.array([
+            2., 9., 10., 11., 12., 13., 9., 10., 11., 12., 13., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 3.,
+        ]).astype(int)
+        expected_output = '12345&12345'
+
+        result = self.formatter.clean_pred(raw_pred)
+
+        self.assertEqual(result, expected_output)
+
+    def test_clean_pred_special_codes(self):
+        raw_pred = np.array([
+            2.,  7.,  7.,  7.,  7.,  7.,  5.,  5.,  5.,  5.,  5.,  9., 10., 11., 12., 13.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1., 3.
+        ]).astype(int)
+        expected_output = '-1&-3&12345'
+
+        result = self.formatter.clean_pred(raw_pred)
+
+        self.assertEqual(result, expected_output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a utility to transform "raw" labels into a format suitable for seq2seq based models. Its focus is explicitly on "blocky" codings, where each HISCO code in a sequence occupies five spots in target array. Functionality is contained within the `BlockyHISCOFormatter` class and is accessible from the `blocky5` constructor function, which is a shorthand function to build a formatter for sequences of 1-5 HISCO codes.

Further, this PR modifies the `OCCDataset` class by adding an argument `formatter` which, if specified, will transform the target using the specified formatter (for now, this will be an instance of `BlockyHISCOFormatter`).

