### PR TITLE
Seq2seq

### DIFF
--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -267,7 +267,7 @@ class BlockyHISCOFormatter: # TODO consider implementing base formatter class
         keys = DATASETS['keys']()
         self.lookup_hisco = dict(keys[['code', 'hisco']].values)
 
-    def sanitize(self, raw_input: str | pd.DataFrame) -> str | None: # pylint: disable=C0116
+    def sanitize(self, raw_input: str | pd.DataFrame | pd.Series) -> str | None: # pylint: disable=C0116
         if isinstance(raw_input, str) or raw_input is None:
             return raw_input
 
@@ -304,17 +304,18 @@ class BlockyHISCOFormatter: # TODO consider implementing base formatter class
     def num_classes(self) -> list[int]: # pylint: disable=C0116
         return [max(self.map_idx_char) + 1] * self._max_seq_len
 
-    def transform_label(self, raw_input: str | pd.DataFrame) -> np.ndarray | None:
+    def transform_label(self, raw_input: str | pd.DataFrame | pd.Sries) -> np.ndarray | None:
         '''
         Given a sequence of HISCO codes as defined by a str or a 1-row
         pd.DataFrame, return a representaion suitable for a seq2seq model.
 
         Parameters
         ----------
-        raw_input : str | pd.DataFrame
+        raw_input : str | pd.DataFrame | pd.DataFrame
             Either a string of HISCO codes, separated by `self.sep_value`, or a 1-row
             pd.DataFrame with columns `['code1', 'code2', ..., f'code{self.max_num_codes}]`,
-            each an integer present as a key in `self.lookup_hisco`
+            each an integer present as a key in `self.lookup_hisco`, or a pd.Series corresponding
+            to such a 1-row pd.DataFrame
 
             If input is a string, its format, assuming `self.sep_value == '&'`, could be of
             the form '12345&34567&-1', '-3', '67890', i.e., consisting of either five digit

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -304,7 +304,7 @@ class BlockyHISCOFormatter: # TODO consider implementing base formatter class
     def num_classes(self) -> list[int]: # pylint: disable=C0116
         return [max(self.map_idx_char) + 1] * self._max_seq_len
 
-    def transform_label(self, raw_input: str | pd.DataFrame | pd.Sries) -> np.ndarray | None:
+    def transform_label(self, raw_input: str | pd.DataFrame | pd.Series) -> np.ndarray | None:
         '''
         Given a sequence of HISCO codes as defined by a str or a 1-row
         pd.DataFrame, return a representaion suitable for a seq2seq model.

--- a/histocc/layers/__init__.py
+++ b/histocc/layers/__init__.py
@@ -1,0 +1,1 @@
+from .decoder import TransformerDecoder

--- a/histocc/layers/decoder.py
+++ b/histocc/layers/decoder.py
@@ -1,0 +1,100 @@
+import math
+
+import torch
+
+from torch import nn, Tensor
+
+
+class TokenEmbedding(nn.Module):
+    def __init__(self, vocab_size: int, emb_size: int):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, emb_size)
+        self.emb_size = emb_size
+
+    def forward(self, tokens: Tensor):
+        return self.embedding(tokens.long()) * math.sqrt(self.emb_size)
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(
+            self,
+            emb_size: int,
+            dropout: float,
+            maxlen: int = 128, # TODO tune/allow to pass arg
+            ):
+        super().__init__()
+        den = torch.exp(- torch.arange(0, emb_size, 2) * math.log(10000) / emb_size) # pylint: disable=E1101
+        pos = torch.arange(0, maxlen).reshape(maxlen, 1) # pylint: disable=E1101
+        pos_embedding = torch.zeros((maxlen, emb_size)) # pylint: disable=E1101
+        pos_embedding[:, 0::2] = torch.sin(pos * den) # pylint: disable=E1101
+        pos_embedding[:, 1::2] = torch.cos(pos * den) # pylint: disable=E1101
+        pos_embedding = pos_embedding.unsqueeze(-2)
+
+        self.dropout = nn.Dropout(dropout)
+        self.register_buffer('pos_embedding', pos_embedding)
+
+    def forward(self, token_embedding: Tensor):
+        return self.dropout(token_embedding + self.pos_embedding[:token_embedding.size(0), :])
+
+
+class TransformerDecoder(nn.Module):
+    '''
+    Decode sequence, such as the representation of a string by CACNINE.
+    Uses a vanilla transformer decoder architecture.
+
+    '''
+    def __init__(
+            self,
+            num_decoder_layers: int,
+            emb_size: int,
+            nhead: int,
+            vocab_size: int,
+            dim_feedforward: int = 512,
+            dropout: float = 0.1,
+            ):
+        super().__init__()
+
+        decoder_layer = nn.TransformerDecoderLayer(
+            d_model=emb_size,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            )
+
+        self.token_emb = TokenEmbedding(vocab_size, emb_size)
+        self.positional_encoding = PositionalEncoding(emb_size, dropout=dropout)
+        self.decoder = nn.TransformerDecoder(decoder_layer, num_decoder_layers)
+        self.head = nn.Linear(emb_size, vocab_size)
+
+    def forward_features( # pylint: disable=C0116
+            self,
+            memory: Tensor, # i.e., input encoded by CANINE
+            target: Tensor,
+            target_mask: Tensor,
+            target_padding_mask: Tensor,
+            ) -> Tensor:
+        memory = memory.permute(1, 0, 2) # (B, Seq[target], Features) -> (Seq[target], B, Features)
+        target = target.permute(1, 0) # (B, Seq[target]) -> (Seq[target], B)
+
+        target_emb = self.positional_encoding(self.token_emb(target)) # (Seq[target], B, Features)
+        decoder_out = self.decoder(
+            tgt=target_emb,
+            memory=memory,
+            tgt_mask=target_mask,
+            memory_mask=None,
+            tgt_key_padding_mask=target_padding_mask,
+            ) # (Seq[target], B, Features)
+
+        return decoder_out.permute(1, 0, 2) # (B, Seq[target], Features)
+
+    def forward( # pylint: disable=C0116
+            self,
+            memory: Tensor,
+            target: Tensor,
+            target_mask: Tensor,
+            target_padding_mask: Tensor,
+            ) -> Tensor:
+        out = self.forward_features(memory, target, target_mask, target_padding_mask) # (Seq[target], B, Features)
+        out = self.head(out) # (B, Seq[target], vocab_size)
+
+        return out

--- a/histocc/loss/__init__.py
+++ b/histocc/loss/__init__.py
@@ -1,0 +1,1 @@
+from .sequence_loss import Seq2SeqCrossEntropy

--- a/histocc/loss/sequence_loss.py
+++ b/histocc/loss/sequence_loss.py
@@ -1,0 +1,22 @@
+from torch import nn, Tensor
+
+
+class Seq2SeqCrossEntropy(nn.Module):
+    ''' Cross entropy loss for seq2seq models.
+
+    Implemented as Module, i.e. the loss is the __call__ of an instance of the
+    class.
+
+    `yhat` is permuted [B, SEQ_LEN, VOCAB_SIZE] -> [SEQ_LEN, B, VOCAB_SIZE].
+    Note that the first token (BoS) is not predicted, and so the SEQ_LEN is one
+    shorter than the actual length of the sequence. For the same reason, the
+    first element in each sequence in `target` is discarded.
+
+    '''
+
+    def __init__(self, pad_idx: int):
+        super().__init__()
+        self.cross_entropy = nn.CrossEntropyLoss(ignore_index=pad_idx)
+
+    def forward(self, yhat: Tensor, target: Tensor) -> Tensor: # pylint: disable=C0116
+        return self.cross_entropy(yhat.permute(0, 2, 1), target[:, 1:])

--- a/histocc/model_assets.py
+++ b/histocc/model_assets.py
@@ -112,29 +112,15 @@ class CANINEOccupationClassifier(nn.Module):
         return self.out(output)
 
 
-# Build the Classifier for HF hub
-class CANINEOccupationClassifier_hub(nn.Module, PyTorchModelHubMixin):
-    # Constructor class
+class CANINEOccupationClassifier_hub(CANINEOccupationClassifier, PyTorchModelHubMixin):
+    ''' Build the Classifier for HF hub
+    '''
     def __init__(self, config):
-        super().__init__()
-        self.basemodel = getModel(config["model_domain"])
-        self.drop = nn.Dropout(p=config["dropout_rate"])
-        self.out = nn.Linear(self.basemodel.config.hidden_size, config["n_classes"])
-
-    def resize_token_embeddings(self, n):
-        pass # Do nothing CANINE should never be resized
-
-    # Forward propagaion class
-    def forward(self, input_ids, attention_mask):
-        outputs = self.basemodel(
-          input_ids=input_ids,
-          attention_mask=attention_mask
+        super().__init__(
+            n_classes=config["n_classes"],
+            model_domain=config['model_domain'],
+            dropout_rate=config['dropout_rate'],
         )
-        pooled_output = outputs.pooler_output
-
-        #  Add a dropout layer
-        output = self.drop(pooled_output)
-        return self.out(output)
 
 
 # Load model from checkpoint

--- a/histocc/model_assets.py
+++ b/histocc/model_assets.py
@@ -11,7 +11,7 @@ Purpose: Defines model classes
 
 import torch
 
-import torch.nn as nn
+from torch import nn, Tensor
 
 from huggingface_hub import PyTorchModelHubMixin
 
@@ -21,6 +21,9 @@ from transformers import (
     CanineModel,
     AutoTokenizer,
 )
+
+from .layers import TransformerDecoder
+
 
 # Model path from domain
 def modelPath(model_domain, model_size = ""):
@@ -91,7 +94,7 @@ def getModel(model_domain, model_size = ""):
 class CANINEOccupationClassifier(nn.Module):
     # Constructor class
     def __init__(self, n_classes, model_domain, dropout_rate):
-        super(CANINEOccupationClassifier, self).__init__()
+        super().__init__()
         self.basemodel = getModel(model_domain)
         self.drop = nn.Dropout(p=dropout_rate)
         self.out = nn.Linear(self.basemodel.config.hidden_size, n_classes)
@@ -121,6 +124,68 @@ class CANINEOccupationClassifier_hub(CANINEOccupationClassifier, PyTorchModelHub
             model_domain=config['model_domain'],
             dropout_rate=config['dropout_rate'],
         )
+
+
+class Seq2SeqOccCANINE(nn.Module):
+    def __init__(
+            self,
+            model_domain,
+            num_classes: list[int],
+            dropout_rate: float | None = None,
+    ):
+        super().__init__()
+
+        self.seq_len: int = len(num_classes)
+        self.vocab_size: int = max(num_classes) + 1
+        self.dropout_rate: float = dropout_rate if dropout_rate else 0.0
+
+        self.encoder = getModel(model_domain)
+        self.decoder = TransformerDecoder( # TODO add args to __init__
+            num_decoder_layers=3,
+            emb_size=self.encoder.base_model.config.hidden_size,
+            nhead=8,
+            vocab_size=self.vocab_size,
+            dropout=self.dropout_rate,
+        )
+
+    def resize_token_embeddings(self, n):
+        pass # Do nothing CANINE should never be resized
+
+    def encode(
+            self,
+            input_ids: Tensor,
+            attention_mask: Tensor,
+    ) -> Tensor:
+        encoding = self.encoder( # TODO we could potentially avoiding running, e.g., pooling, as we use prev state
+          input_ids=input_ids,
+          attention_mask=attention_mask
+        )
+
+        return encoding.last_hidden_state
+
+    def decode(
+            self,
+            memory: Tensor,
+            target: Tensor,
+            target_mask: Tensor,
+            target_padding_mask: Tensor,
+    ) -> Tensor:
+        out = self.decoder(memory, target, target_mask, target_padding_mask)
+
+        return out
+
+    def forward(
+            self,
+            input_ids: Tensor,
+            attention_mask: Tensor,
+            target: Tensor,
+            target_mask: Tensor,
+            target_padding_mask: Tensor,
+    ) -> Tensor:
+        memory = self.encode(input_ids, attention_mask)
+        out = self.decode(memory, target, target_mask, target_padding_mask)
+
+        return out
 
 
 # Load model from checkpoint

--- a/histocc/seq2seq_engine.py
+++ b/histocc/seq2seq_engine.py
@@ -1,0 +1,204 @@
+import time
+
+import torch
+
+from torch import nn, Tensor
+
+from .formatter import PAD_IDX
+from .utils import create_mask
+
+
+class Averager:
+    def __init__(self):
+        self.sum: int | float = 0
+        self.count: int = 0
+
+    @property
+    def avg(self) -> float:
+        return self.sum / self.count
+
+    def update(self, val: int | float, num: int = 1):
+        self.sum += val * num
+        self.count += num
+
+
+def seq2seq_sequence_accuracy(
+        output: Tensor,
+        target: Tensor,
+        pad_idx: int,
+        ) -> tuple[Tensor, Tensor]:
+    """
+    Calculate the sequence and token accuracies of a seq2seq-style output and
+    target. In both calculations, all indexes of `target` that correspond to
+    padding are omitted from the calculations. Note that the token accuracy
+    weighs longer sequences higher (proportional to length). However, as this
+    function is likely called on batches (rather than entire data set), this
+    will only be true in a batch-wise sense and the final token accuracy will
+    weigh observations proportional to their length within batches but
+    uniformly across batches.
+
+    Parameters
+    ----------
+    output : Tensor
+        [B, SeqLen, Features]-shaped model output.
+    target : Tensor
+        [B, SeqLen]-shaped targets.
+    pad_idx : int
+        Which index used to represent padding.
+
+    Returns
+    -------
+    (Tensor, Tensor)
+        1-element tensors with the sequence and token accuracy, respectively.
+
+    """
+    max_index = torch.argmax(output, dim=2).detach().cpu() # pylint: disable=E1101
+    _target = target.clone() # To allow in-place operations to not change input
+
+    # Padded elements should not be accounted for in calculation; set to -1 to
+    # ensure they match, allowing the calculation of sequence accuracy used
+    target_padding_mask = (_target == pad_idx)
+    max_index[target_padding_mask] = -1
+    _target[target_padding_mask] = -1
+
+    is_eq = max_index == _target.detach().cpu()
+    seq_acc = 100 * is_eq.all(axis=1).float().mean()
+
+    # When calculating token accuracy, make sure not to inflate with the padded
+    # values; hence remove those from both numerator and enumerator
+    token_acc = 100 * (is_eq.float().sum() - target_padding_mask.sum()) / (~target_padding_mask).sum()
+
+    return seq_acc, token_acc
+
+
+def train_one_epoch(
+        model: nn.Module,
+        data_loader: torch.utils.data.DataLoader,
+        loss_fn: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        scheduler: torch.optim.lr_scheduler.LRScheduler,
+        log_interval: int = 100,
+        ) -> tuple[float, float]:
+    model = model.train()
+
+    losses = Averager()
+    batch_time = Averager()
+
+    for batch_idx, batch in enumerate(data_loader):
+        start = time.time()
+
+        input_ids = batch["input_ids"].to(device)
+        attention_mask = batch["attention_mask"].to(device)
+        targets = batch['targets'].to(device)
+
+        # Prepare target as input for seq2seq model
+        target_input = targets[:, :-1]
+        target_mask, target_padding_mask = create_mask(target_input, PAD_IDX, device)
+
+        # Forward pass
+        outputs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            target=target_input,
+            target_mask=target_mask,
+            target_padding_mask=target_padding_mask,
+        )
+
+        loss = loss_fn(outputs, targets)
+        losses.update(loss.item(), outputs.size(0))
+
+        # Backward pass & step
+        optimizer.zero_grad()
+        loss.backward()
+
+        nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+
+        optimizer.step()
+        scheduler.step()
+
+        batch_time.update(time.time() - start)
+
+        if batch_idx % log_interval == 0:
+            print(f'Batch {batch_idx + 1} of {len(data_loader)}')
+            print(f'Average loss: {losses.avg}')
+            print(f'Average batch time: {batch_time.avg}')
+
+    return losses.avg, batch_time.avg
+
+
+@torch.no_grad
+def evaluate(
+        model: nn.Module,
+        data_loader: torch.utils.data.DataLoader,
+        loss_fn: nn.Module,
+        device: torch.device,
+        ):
+    model = model.eval()
+
+    losses = Averager()
+    token_accs = Averager()
+    seq_accs = Averager()
+
+    for batch in data_loader:
+        input_ids = batch["input_ids"].to(device)
+        attention_mask = batch["attention_mask"].to(device)
+        targets = batch['targets'].to(device)
+
+        # Prepare target as input for seq2seq model
+        target_input = targets[:, :-1]
+        target_mask, target_padding_mask = create_mask(target_input, PAD_IDX, device)
+
+        # Forward pass
+        outputs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            target=target_input,
+            target_mask=target_mask,
+            target_padding_mask=target_padding_mask,
+        )
+
+        loss = loss_fn(outputs, targets)
+        losses.update(loss.item(), outputs.size(0))
+
+        seq_acc, token_acc = seq2seq_sequence_accuracy( # FIXME some issue where seq acc > token acc
+            outputs, targets[:, 1:], PAD_IDX,
+        )
+        seq_accs.update(seq_acc, outputs.size(0))
+        token_accs.update(token_acc, outputs.size(0))
+
+    return losses.avg, seq_accs.avg, token_accs.avg
+
+
+def train(
+        epochs: int,
+        model: nn.Module,
+        data_loaders: dict[str, torch.utils.data.DataLoader], # TODO split or use dataclass
+        loss_fn: nn.Module,
+        optimizer,
+        device,
+        scheduler,
+        ):
+    for epoch in range(1, epochs + 1):
+        print(f'Epoch {epoch} of {epochs}')
+
+        avg_train_loss, avg_batch_time = train_one_epoch(
+            model,
+            data_loaders['data_loader_train'],
+            loss_fn,
+            optimizer,
+            device,
+            scheduler,
+        )
+
+        # Evaluate
+        val_loss, seq_acc, token_acc = evaluate(
+            model,
+            data_loaders['data_loader_val'],
+            loss_fn,
+            device,
+            )
+
+        print(f'Validation loss: {val_loss}')
+        print(f'Validation sequence accuracy: {seq_acc}')
+        print(f'Validation token accuracy: {token_acc}')

--- a/histocc/seq2seq_wrapper.py
+++ b/histocc/seq2seq_wrapper.py
@@ -1,0 +1,84 @@
+import torch
+
+from torch import nn
+from torch.optim import AdamW
+from transformers import get_linear_schedule_with_warmup
+
+from .model_assets import Seq2SeqOccCANINE
+from .prediction_assets import OccCANINE, get_adapated_tokenizer
+from .seq2seq_engine import train
+from .loss import Seq2SeqCrossEntropy
+from .formatter import PAD_IDX
+
+
+class Seq2SeqOccCANINEWrapper(OccCANINE):
+    def __init__( # pylint: disable=W0231
+            self,
+            name: str = "CANINE",
+            device: str | None = None,
+            batch_size: int = 256,
+            verbose: bool = False,
+            hf: bool = True,
+    ):
+        # Detect device
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu") if device is None else torch.device(device)
+        if verbose:
+            print(f"Using device: {self.device}")
+
+        if name == "CANINE" and not hf:
+            raise ValueError("When 'hf' is False, a specific local model 'name' must be provided.")
+
+        self.name = name
+        self.batch_size = batch_size
+        self.verbose = verbose
+
+        # Get tokenizer
+        self.tokenizer = get_adapated_tokenizer("CANINE_Multilingual_CANINE_sample_size_10_lr_2e-05_batch_size_256")
+
+        # Get key
+        self.key, self.key_desc = self._load_keys()
+        self.model = self.init_seq2seq_model()
+
+        # Promise for later initialization
+        self.finetune_key = None
+
+    def init_seq2seq_model(self) -> nn.Module:
+        model = Seq2SeqOccCANINE(
+            model_domain='Multilingual_CANINE', # TODO make arg
+            num_classes=[18] * 27, # TODO make arg, extract from formatter
+        ).to(self.device)
+
+        return model
+
+    def _train_model(
+            self,
+            processed_data,
+            model_name,
+            epochs,
+            only_train_final_layer,
+            verbose = True,
+            verbose_extra = False,
+            new_labels = False,
+            save_model = True,
+            save_path = '../OccCANINE/Finetuned/',
+            ):
+        optimizer = AdamW(self.model.parameters(), lr=2*10**-5)
+        total_steps = len(processed_data['data_loader_train']) * epochs
+        scheduler = get_linear_schedule_with_warmup(
+            optimizer,
+            num_warmup_steps=0,
+            num_training_steps=total_steps,
+        )
+
+        # Set the loss function
+        loss_fn = Seq2SeqCrossEntropy(pad_idx=PAD_IDX).to(self.device)
+
+        train(
+            epochs=epochs,
+            model=self.model,
+            data_loaders=processed_data,
+            loss_fn=loss_fn,
+            optimizer=optimizer,
+            device=self.device,
+            scheduler=scheduler,
+            )

--- a/histocc/utils/__init__.py
+++ b/histocc/utils/__init__.py
@@ -1,0 +1,1 @@
+from .masking import create_mask

--- a/histocc/utils/masking.py
+++ b/histocc/utils/masking.py
@@ -1,0 +1,98 @@
+"""
+@author: sa-tsdj
+
+"""
+
+
+import torch
+
+from torch import Tensor
+
+
+def generate_square_subsequent_mask(
+        seq_len: int,
+        device: torch.device | str = 'cuda', # pylint: disable=E1101
+        ) -> Tensor:
+    """
+    Create mask of target for seq2seq models. Mask of target is used to mask
+    out future elements in sequence.
+
+    Note that `target_input` is 1 element shorter than the sequences, as the last
+    element of each sequence has been discarded, as the last element is not
+    used as input. This also means `seq_len` is one less than the true length
+    of the sequences.
+
+    Parameters
+    ----------
+    seq_len : int
+        Length of sequences - 1, as last element of each sequence is not used
+        as input. This means `seq_len = SEQ_LEN - 1`.
+    device : Union[torch.device, str], optional
+        Which device to create tensors at. The default is 'cuda'.
+
+    Returns
+    -------
+    Tensor
+        Target mask of shape [SEQ_LEN - 1, SEQ_LEN - 1]. Example where
+        SEQ_LEN - 1 == 3:
+            [[0, -inf, -inf],
+             [0,    0, -inf],
+             [0,    0,    0]].
+
+    """
+    mask = (torch.triu(torch.ones((seq_len, seq_len), device=device)) == 1).transpose(0, 1) # pylint: disable=E1101
+    mask = mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
+
+    return mask
+
+
+def create_mask(
+        target_input: Tensor,
+        pad_idx: int,
+        device: torch.device | str = 'cuda', # pylint: disable=E1101
+        ) -> tuple[Tensor, Tensor]:
+    """
+    Create mask of target and padding for seq2seq models. Mask of target is
+    used to mask out future elements in sequence and mask of padding is used to
+    mask out elements placed at end of sequences to pad all sequences to same
+    length.
+
+    Note that `target_input` is 1 element shorter than the sequences, as the last
+    element of each sequence has been discarded, as the last element is not
+    used as input. This also means `seq_len` is one less than the true length
+    of the sequences.
+
+    Implementation based on https://pytorch.org/tutorials/beginner/translation_transformer.html
+
+    Parameters
+    ----------
+    target_input : Tensor
+        Target input of shape [BATCH_SIZE, SEQ_LEN - 1], the last element of
+        each sequence discarded as that is not used as input.
+    pad_idx : int
+        Index used to denote padding.
+    device : Union[torch.device, str], optional
+        Which device to create tensors at. The default is 'cuda'.
+
+    Returns
+    -------
+    target_mask : Tensor
+        Target mask of shape [SEQ_LEN - 1, SEQ_LEN - 1]. Example where
+        SEQ_LEN - 1 == 3:
+            [[0, -inf, -inf],
+             [0,    0, -inf],
+             [0,    0,    0]]
+    target_padding_mask : Tensor
+        Padding mask of shape [BATCH_SIZE, SEQ_LEN - 1]. Example where
+        BATCH_SIZE == 2, SEQ_LEN - 1 == 3, and the second sequence has padding
+        on last element:
+            [[FALSE, FALSE, FALSE],
+             [FALSE, FALSE,  TRUE]]
+
+    """
+    seq_len = target_input.shape[1]
+
+    target_mask = generate_square_subsequent_mask(seq_len, device)
+    target_padding_mask = (target_input == pad_idx).to(dtype=target_mask.dtype)
+
+    return target_mask, target_padding_mask


### PR DESCRIPTION
This PR implements a seq2seq-style `OccCANINE` model. Further, a vanilla loss fn is implemented for testing purposes and the core components of the train and eval loop have been implemented

Several things are still missing before this becomes directly usable. First, some work on the data loading side is required. Second, a new entry-point to reflect the seq2seq-style approach should be built. Third, an AR decoding scheme (e.g., greedy) needs to be developed before inference is possible. However, as those are not directly related to the core seq2seq model components, I plan to implement those in a new branch