### PR TITLE
Seq2seq dataset

### DIFF
--- a/histocc/__init__.py
+++ b/histocc/__init__.py
@@ -3,8 +3,16 @@ from .datasets import DATASETS
 from .model_assets import (
     CANINEOccupationClassifier,
     CANINEOccupationClassifier_hub,
+    Seq2SeqOccCANINE,
     load_model_from_checkpoint,
+    load_tokenizer,
     )
 from .trainer import trainer_loop
-from .dataloader import load_data
+from .dataloader import (
+    load_data,
+    OccDatasetV2,
+    OccDatasetV2InMem,
+)
+from .loss import Seq2SeqCrossEntropy
 from . import formatter
+from . import seq2seq_engine

--- a/histocc/dataloader.py
+++ b/histocc/dataloader.py
@@ -532,7 +532,7 @@ class OccDatasetV2(Dataset):
             file.seek(self.map_item_byte_index[item])
             row = file.readline()
             data = pd.read_csv(
-                io.StringIO(row.decode('utf-8')), 
+                io.StringIO(row.decode('utf-8')),
                 names=self.colnames,
                 dtype={'occ1': str}, # TODO define full dtype-mapping in self.__init__
                 )
@@ -562,7 +562,7 @@ class OccDatasetV2(Dataset):
         if random.random() < self.unk_lang_prob:
             lang = 'unk'
 
-        return '[SEP]'.join((occ_descr, lang))
+        return '[SEP]'.join((lang, occ_descr)) # TODO '[SEP]' should be a (global) const
 
     def __len__(self) -> int:
         return len(self.map_item_byte_index)
@@ -575,7 +575,7 @@ class OccDatasetV2(Dataset):
         target = self.formatter.transform_label(record)
 
         # Augment occupational description and language and
-        # return '<LANG>[SEP]<OCCUPATIONAL DESCRIPTION'
+        # return '<LANG>[SEP]<OCCUPATIONAL DESCRIPTION>'
         input_seq = self._prepare_input(occ_descr, lang)
 
         # Encode input sequence
@@ -625,7 +625,10 @@ class OccDatasetV2InMem(OccDatasetV2):
             use_textattack=use_textattack,
             unk_lang_prob=unk_lang_prob,
         )
-        self.frame = pd.read_csv(fname_data)
+        self.frame = pd.read_csv(
+            fname_data,
+            usecols=['occ1', 'lang', 'code1', 'code2', 'code3', 'code4', 'code5'],
+        )
 
     def _setup_mapping(self, fname_index: str) -> dict[int, int]:
         ''' We avoid using any mapping when loading dataset into memory,

--- a/histocc/dataloader.py
+++ b/histocc/dataloader.py
@@ -5,8 +5,9 @@ https://medium.com/@keruchen/train-a-xlm-roberta-model-for-text-classification-o
 @author: chris
 """
 
-import os
+
 import io
+import os
 import random
 
 from functools import partial
@@ -15,7 +16,9 @@ from typing import Callable
 import torch
 
 from sklearn.model_selection import train_test_split
+from torch import Tensor
 from torch.utils.data import Dataset, DataLoader
+from transformers import CanineTokenizer
 
 import numpy as np
 import pandas as pd
@@ -227,21 +230,22 @@ def resample(
             plt.xscale('log')
             plt.show()
 
-    # Return result
     return df
 
-#Downsample
-# Subset to smaller
+
 def subset_to_smaller(df, sample_size):
+    ''' Downsample
+    '''
     if 10 ** sample_size < df.shape[0]:
         random.seed(20)
         df = df.sample(10**sample_size, random_state=20)
 
     return df
 
-# Labels to bin function
-# Returns binary array
+
 def labels_to_bin(df: pd.DataFrame, max_value: int):
+    ''' Returns binary array
+    '''
     df_codes = df[["code1", "code2", "code3", "code4", "code5"]]
 
     if len(df) == 1: # Handle single row efficiently
@@ -287,7 +291,7 @@ def labels_to_bin(df: pd.DataFrame, max_value: int):
 
     return labels
 
-# Reference loss
+
 def reference_loss(df):
     if len(df) >= 10000:
         # Downsample to 10000 observations
@@ -310,7 +314,6 @@ def reference_loss(df):
     return reference_bce
 
 
-# ReadData
 def read_sample_subset_data(
     model_domain,
     downsample_top1 = True,
@@ -325,7 +328,7 @@ def read_sample_subset_data(
 
     return df, key
 
-# Train test val split
+
 def train_test_val(df, verbose = False, max_testval = 10**5, testval_fraction = 0.05, test_size = 0.5):
     # Note: More test and validation data exists in sepperate files
     # Test/val size limited to 'max_testval' observations
@@ -352,6 +355,7 @@ def concat_string(occ1, lang):
 
     return(cat_sequence)
 
+
 def concat_string_canine(occ1, lang):
     occ1 = str(occ1).strip("'[]'") # pylint: disable=E1310
     # Implement random change to lang 'unknown' here:
@@ -359,7 +363,7 @@ def concat_string_canine(occ1, lang):
 
     return(cat_sequence)
 
-#Dataset
+
 class OCCDataset(Dataset):
     transform_label: Callable
     # Constructor Function
@@ -400,7 +404,7 @@ class OCCDataset(Dataset):
             os.makedirs(os.path.dirname(df_path))
 
         # Load and store index file in memory
-        with open(index_file_path, 'r') as index_file:
+        with open(index_file_path, 'r', encoding='utf-8') as index_file:
             self.index_data = index_file.readlines()
 
     def setup_target_formatter(self):
@@ -473,8 +477,167 @@ class OCCDataset(Dataset):
             'occ1': cat_sequence,
             'input_ids': encoding['input_ids'].flatten(),
             'attention_mask': encoding['attention_mask'].flatten(),
-            'targets': torch.tensor(target, dtype=torch.long) # FIXME consider appropriate type and align with formatter
+            'targets': torch.tensor(target, dtype=torch.long),
         }
+
+
+class OccDatasetV2(Dataset):
+    def __init__(
+            self,
+            fname_data: str,
+            fname_index: str,
+            formatter: BlockyHISCOFormatter,
+            tokenizer: CanineTokenizer,
+            max_input_len: int,
+            alt_prob: float = 0.0,
+            insert_words: bool = False,
+            use_textattack: bool = False,
+            unk_lang_prob: float = 0.0,
+    ):
+        self.fname_data = fname_data
+        self.formatter = formatter
+        self.tokenizer = tokenizer
+        self.max_input_len = max_input_len
+        self.alt_prob = alt_prob
+        self.insert_words = insert_words
+        self.use_textattack = use_textattack
+        self.unk_lang_prob = unk_lang_prob
+
+        self.colnames: pd.Index = pd.read_csv(fname_data, nrows=1).columns
+        self.map_item_byte_index = self._setup_mapping(fname_index)
+        # FIXME current impl can mistakenly read an 'occ1' value as an int
+        # TODO have `self._get_record` pass in coltypes
+        # Example value for 'occ1': 42
+        # This is then read as an int; since we read 1 row at a time, we
+        # may wrongly infer type in such cases
+
+        if use_textattack:
+            # attacker = AttackerClass(...)
+            # self.attack = attacker.attack
+            raise NotImplementedError('Use of `AttackerClass` not supported yet')
+        else:
+            self.attack = self._no_attack
+
+    def _setup_mapping(self, fname_index: str) -> dict[int, int]:
+        # TODO ask Vedel about structure. Is shuffling implemented?
+        # Cannot seem to grab expected elements
+
+        with open(fname_index, 'r', encoding='utf-8') as file:
+            byte_offsets = file.readlines()
+
+        return {idx: int(offset) for idx, offset in enumerate(byte_offsets)}
+
+    def _get_record(self, item: int) -> pd.Series:
+        with open(self.fname_data, 'rb') as file:
+            file.seek(self.map_item_byte_index[item])
+            row = file.readline()
+            data = pd.read_csv(
+                io.StringIO(row.decode('utf-8')), 
+                names=self.colnames,
+                dtype={'occ1': str}, # TODO define full dtype-mapping in self.__init__
+                )
+
+        return data.iloc[0]
+
+    def _no_attack(
+            self,
+            x_string: str,
+            alt_prob: float, # pylint: disable=W0613
+            insert_words: bool, # pylint: disable=W0613
+            use_textattack: bool, # pylint: disable=W0613
+    )  -> str:
+        ''' Fallback option when `AttackerClass` not available
+        '''
+        return x_string
+
+    def _prepare_input(self, occ_descr: str, lang: str) -> str:
+        occ_descr: str = self.attack( # TODO pass in params at construction since fixed? No need to feed as input each call
+            x_string=occ_descr,
+            alt_prob=self.alt_prob,
+            insert_words=self.insert_words,
+            use_textattack=self.use_textattack,
+        ) # FIXME need to fix output type. Seems could be str or list[str] as is
+        occ_descr = occ_descr.strip("'[]'") # TODO should probably happen before we augment
+
+        if random.random() < self.unk_lang_prob:
+            lang = 'unk'
+
+        return '[SEP]'.join((occ_descr, lang))
+
+    def __len__(self) -> int:
+        return len(self.map_item_byte_index)
+
+    def __getitem__(self, item: int) -> dict[str, str | Tensor]:
+        record = self._get_record(item)
+
+        occ_descr: str = record.occ1
+        lang: str = record.lang
+        target = self.formatter.transform_label(record)
+
+        # Augment occupational description and language and
+        # return '<LANG>[SEP]<OCCUPATIONAL DESCRIPTION'
+        input_seq = self._prepare_input(occ_descr, lang)
+
+        # Encode input sequence
+        encoded_input_seq = self.tokenizer.encode_plus(
+            input_seq,
+            add_special_tokens=True,
+            padding='max_length',
+            max_length=self.max_input_len,
+            return_token_type_ids=False,
+            return_attention_mask=True,
+            return_tensors='pt',
+            truncation = True
+        )
+
+        batch_data = {
+            'occ1': input_seq, # Legacy name of 'input_seq'
+            'input_seq': input_seq,
+            'input_ids': encoded_input_seq['input_ids'].flatten(),
+            'attention_mask': encoded_input_seq['attention_mask'].flatten(),
+            'targets': torch.tensor(target, dtype=torch.long),
+        }
+
+        return batch_data
+
+
+class OccDatasetV2InMem(OccDatasetV2):
+    def __init__(
+            self,
+            fname_data: str,
+            fname_index: str,
+            formatter: BlockyHISCOFormatter,
+            tokenizer: CanineTokenizer,
+            max_input_len: int,
+            alt_prob: float = 0.0,
+            insert_words: bool = False,
+            use_textattack: bool = False,
+            unk_lang_prob: float = 0.0,
+    ):
+        super().__init__(
+            fname_data=fname_data,
+            fname_index=fname_index,
+            formatter=formatter,
+            tokenizer=tokenizer,
+            max_input_len=max_input_len,
+            alt_prob=alt_prob,
+            insert_words=insert_words,
+            use_textattack=use_textattack,
+            unk_lang_prob=unk_lang_prob,
+        )
+        self.frame = pd.read_csv(fname_data)
+
+    def _setup_mapping(self, fname_index: str) -> dict[int, int]:
+        ''' We avoid using any mapping when loading dataset into memory,
+        hence overwrite with ghost method
+        '''
+        return {}
+
+    def _get_record(self, item: int) -> pd.Series:
+        return self.frame.iloc[item]
+
+    def __len__(self) -> int:
+        return len(self.frame)
 
 
 def datasets(


### PR DESCRIPTION
This PR adds a new `Dataset` class, namely `OccDatasetV2`, as well as a modified version which keeps data in memory (`OccDatasetV2InMem`). Its purpose is to be used to train the seq2seq-based model, as well as general improvements such as arbitrary formatter support and the extension to work with all data in memory.

The current implementation has certain limitations, particularly related to input-side augmentation. As such, this PR should serve as a starting point for discussion on how to integrate our new input-side data augmentation once it's ready, as well as general feedback on the new proposed `Dataset` structure.