### PR TITLE
Entrypoint for seq2seq-style model training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ histocc/Data/Tmp_finetune/
 
 # W&B
 /wandb/
+
+# Helper scripts not for sharing
+/helper_scripts/

--- a/histocc/attacker.py
+++ b/histocc/attacker.py
@@ -53,8 +53,6 @@ class AttackerClass:
         ]
 
         if df is not None:
-            # TODO discuss if we want to weight the words. Current
-            # no-duplicates approach does not sample with weights
             all_text = ' '.join(item for item in df['occ1'].unique())
             self.word_list = list(set(all_text.split()))
             self.transformations.append(self.insert_random_word)

--- a/histocc/formatter/hisco.py
+++ b/histocc/formatter/hisco.py
@@ -297,7 +297,7 @@ class BlockyHISCOFormatter: # TODO consider implementing base formatter class
 
     @property
     def max_seq_len(self) -> int: # pylint: disable=C0116
-        print(f'Max. seq. len.: {self.max_num_codes} * 5 + 2, since BOS and EOS token.')
+        # Max. seq. len.: {self.max_num_codes} * 5 + 2, since BOS and EOS token.
         return self._max_seq_len
 
     @property

--- a/histocc/model_assets.py
+++ b/histocc/model_assets.py
@@ -132,6 +132,7 @@ class Seq2SeqOccCANINE(nn.Module):
             model_domain,
             num_classes: list[int],
             dropout_rate: float | None = None,
+            decoder_dim_feedforward: int | None = None,
     ):
         super().__init__()
 
@@ -140,11 +141,14 @@ class Seq2SeqOccCANINE(nn.Module):
         self.dropout_rate: float = dropout_rate if dropout_rate else 0.0
 
         self.encoder = getModel(model_domain)
-        self.decoder = TransformerDecoder( # TODO add args to __init__
+        self.decoder_dim_feedforward = decoder_dim_feedforward if decoder_dim_feedforward else self.encoder.base_model.config.hidden_size
+
+        self.decoder = TransformerDecoder(
             num_decoder_layers=3,
             emb_size=self.encoder.base_model.config.hidden_size,
             nhead=8,
             vocab_size=self.vocab_size,
+            dim_feedforward=self.decoder_dim_feedforward,
             dropout=self.dropout_rate,
         )
 

--- a/histocc/seq2seq_engine.py
+++ b/histocc/seq2seq_engine.py
@@ -6,10 +6,12 @@ import torch
 from torch import nn
 
 from .formatter import PAD_IDX
-from .utils import create_mask, Averager
-
-from .utils.metrics import order_invariant_accuracy
-from .utils.log_util import update_summary
+from .utils import (
+    create_mask,
+    Averager,
+    order_invariant_accuracy,
+    update_summary,
+)
 
 
 def train_one_epoch(
@@ -79,9 +81,6 @@ def train_one_epoch(
 
         if batch_idx % log_interval == 0 or batch_idx == last_step:
             print(f'Batch {batch_idx + 1} of {len(data_loader)}. Batch time (data): {batch_time.avg:.2f} ({batch_time_data.avg:.2f}). Train loss: {losses.avg:.2f}')
-            # print(f'Average training loss: {losses.avg:.2f}')
-            # print(f'Average batch time: {batch_time.avg:.2f}')
-            # print(f'Average data batch time: {batch_time_data.avg:.2f}')
             # print(f'Samples/second: {samples_per_sec.avg:.2f}')
             # print(f'Max. memory allocated/reserved: {torch.cuda.max_memory_allocated() / (1024 ** 3):.2f}/{torch.cuda.max_memory_reserved() / (1024 ** 3):.2f} GB')
 
@@ -92,6 +91,7 @@ def train_one_epoch(
                 'scheduler': scheduler.state_dict(),
                 'step': current_step,
             }
+            torch.save(states, os.path.join(save_dir, f'{current_step}.bin'))
             torch.save(states, os.path.join(save_dir, 'last.bin'))
 
         if eval_interval is not None and current_step % eval_interval == 0:

--- a/histocc/utils/__init__.py
+++ b/histocc/utils/__init__.py
@@ -2,4 +2,6 @@ from .masking import create_mask
 from .metrics import (
     Averager,
     seq2seq_sequence_accuracy,
+    order_invariant_accuracy,
 )
+from .log_util import wandb_init, update_summary

--- a/histocc/utils/metrics.py
+++ b/histocc/utils/metrics.py
@@ -104,6 +104,9 @@ def order_invariant_accuracy(
     # correct. We probably want to treat as a case an incorrect to
     # not inflate accuracy
 
+    # TODO consider implementation which discard PAD_IDX
+    # values token accuracy to get more meaningful metric
+
     hits = []
 
     for target_block in range(nb_blocks):

--- a/train.md
+++ b/train.md
@@ -1,0 +1,70 @@
+# Settings for training experiments
+
+## Data references
+```
+SET TRAIN_DATA=Z:/faellesmappe/tsdj/hisco/data/Training_data\CA_bcn_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\DK_cedar_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\DK_census_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\DK_orsted_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_ca_ipums_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_loc_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_marr_cert_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_oclack_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_parish_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_patentee_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_PortArthur_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_ship_data_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_uk_ipums_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\EN_us_ipums_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\FR_desc_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\GE_ipums_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\GE_occupational_census_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\GE_occupations1939_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\GE_Selgert_Gottlich_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\HISCO_website_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\HSN_database_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\IS_ipums_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\IT_fm_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\JIW_database_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\NO_ipums_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\SE_cedar_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\SE_chalmers_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\SE_swedpop_train.csv Z:/faellesmappe/tsdj/hisco/data/Training_data\SE_titles_train.csv Z:/faellesmappe/tsdj/hisco/data/Adversarial_data/Adv_data_double_translateFalse.csv Z:/faellesmappe/tsdj/hisco/data/Adversarial_data/Adv_data_double_translateTrue.csv Z:/faellesmappe/tsdj/hisco/data/Adversarial_data/Random_strings.csv Z:/faellesmappe/tsdj/hisco/data/Adversarial_data/Translated_data.csv
+
+SET VAL_DATA=Z:/faellesmappe/tsdj/hisco/data/Validation_data1\CA_bcn_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\DK_cedar_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\DK_census_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\DK_orsted_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_ca_ipums_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_loc_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_marr_cert_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_oclack_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_parish_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_patentee_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_PortArthur_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_ship_data_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_uk_ipums_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\EN_us_ipums_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\FR_desc_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\GE_ipums_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\GE_occupational_census_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\GE_occupations1939_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\GE_Selgert_Gottlich_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\HISCO_website_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\HSN_database_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\IS_ipums_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\IT_fm_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\JIW_database_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\NO_ipums_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\SE_cedar_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\SE_chalmers_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\SE_swedpop_val1.csv Z:/faellesmappe/tsdj/hisco/data/Validation_data1\SE_titles_val1.csv
+```
+
+## Baseline
+
+Initialize encoder using `OccCANINE-V1`, warmup for 3000 steps, no decoder dropout,
+```
+SET CUDA_VISIBLE_DEVICES=1
+python train_v2.py --save-dir Z:/faellesmappe/tsdj/hisco/v2/baseline --train-data %TRAIN_DATA% --val-data %VAL_DATA% --log-interval 50 --eval-interval 15000 --save-interval 5000 --log-wandb --warmup-steps 3000 --initial-checkpoint occ-canine-v1
+```
+
+## Dropout
+
+Baseline, but with 10% decoder dropout
+```
+SET CUDA_VISIBLE_DEVICES=2
+python train_v2.py --save-dir Z:/faellesmappe/tsdj/hisco/v2/dropout --train-data %TRAIN_DATA% --val-data %VAL_DATA% --log-interval 50 --eval-interval 15000 --save-interval 5000 --log-wandb --warmup-steps 3000 --initial-checkpoint occ-canine-v1 --dropout 0.1
+```
+
+## CANINE initialization
+
+Baseline, but initializing encoder from CANINE rather than OccCANINE
+```
+SET CUDA_VISIBLE_DEVICES=3
+python train_v2.py --save-dir Z:/faellesmappe/tsdj/hisco/v2/canine-init --train-data %TRAIN_DATA% --val-data %VAL_DATA% --log-interval 50 --eval-interval 15000 --save-interval 5000 --log-wandb --warmup-steps 3000
+```
+
+## CANINE initialization, dropout
+
+Baseline, but initializing encoder from CANINE rather than OccCANINE and using 10% decoder dropout
+```
+SET CUDA_VISIBLE_DEVICES=0
+python train_v2.py --save-dir Z:/faellesmappe/tsdj/hisco/v2/canine-init-dropout --train-data %TRAIN_DATA% --val-data %VAL_DATA% --log-interval 50 --eval-interval 15000 --save-interval 5000 --log-wandb --warmup-steps 3000 --dropout 0.1
+```
+
+# Evaluation
+
+## Baseline
+
+```
+SET CUDA_VISIBLE_DEVICES=1
+python eval_v2.py --val-data %VAL_DATA% --checkpoint Z:/faellesmappe/tsdj/hisco/v2/baseline/95000.bin --fn-out Z:/faellesmappe/tsdj/hisco/v2/baseline/95000.csv
+```
+
+## Dropout
+
+```
+SET CUDA_VISIBLE_DEVICES=2
+python eval_v2.py --val-data %VAL_DATA% --checkpoint Z:/faellesmappe/tsdj/hisco/v2/dropout/95000.bin --fn-out Z:/faellesmappe/tsdj/hisco/v2/dropout/95000.csv
+```
+
+## CANINE initialization
+
+```
+SET CUDA_VISIBLE_DEVICES=3
+python eval_v2.py --val-data %VAL_DATA% --checkpoint Z:/faellesmappe/tsdj/hisco/v2/canine-init/95000.bin --fn-out Z:/faellesmappe/tsdj/hisco/v2/canine-init/95000.csv
+```
+
+## CANINE initialization, dropout
+
+```
+SET CUDA_VISIBLE_DEVICES=0
+python eval_v2.py --val-data %VAL_DATA% --checkpoint Z:/faellesmappe/tsdj/hisco/v2/canine-init-dropout/95000.bin --fn-out Z:/faellesmappe/tsdj/hisco/v2/canine-init-dropout/95000.csv
+```

--- a/train_v2.py
+++ b/train_v2.py
@@ -1,0 +1,260 @@
+'''
+Example use:
+    python train_v2.py ^
+    --train-data Y:/pc-to-Y/Train.csv ^
+    --val-data C:/Users/sa-tsdj/Documents/GitHub/OccCANINE/Data/Tmp_finetune/Val.csv
+
+--train-data Y:/pc-to-Y/Train.csv --val-data C:/Users/sa-tsdj/Documents/GitHub/OccCANINE/Data/Tmp_finetune/Val.csv
+'''
+
+
+import argparse
+import os
+import yaml
+
+import torch
+
+from torch.optim import AdamW
+from torch.utils.data import DataLoader
+from transformers import (
+    get_linear_schedule_with_warmup,
+    CanineTokenizer,
+)
+
+from histocc import (
+    OccDatasetV2InMemMultipleFiles,
+    load_tokenizer,
+    Seq2SeqOccCANINE,
+    BlockOrderInvariantLoss,
+)
+from histocc.seq2seq_engine import train
+from histocc.formatter import (
+    blocky5,
+    BlockyHISCOFormatter,
+    PAD_IDX,
+)
+from histocc.utils import wandb_init
+
+from histocc.model_assets import CANINEOccupationClassifier_hub
+
+try:
+    # want to do import to set has_wandb even if not used directly
+    import wandb # pylint: disable=W0611
+    has_wandb = True # pylint: disable=C0103
+except ImportError:
+    has_wandb = False # pylint: disable=C0103
+
+# TODO torch.cudnn.benchmark
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    # File paths, data & model choices
+    parser.add_argument('--save-dir', type=str, default=None)
+    parser.add_argument('--save-interval', type=int, default=5000, help='Number of steps between saving model')
+    parser.add_argument('--initial-checkpoint', type=str, default=None, help='Model weights to use for initialization. Discarded if resume state exists at --save-dir')
+
+    parser.add_argument('--train-data', type=str, default=None, nargs='+')
+    parser.add_argument('--val-data', type=str, default=None, nargs='+')
+
+    # Logging parameters
+    parser.add_argument('--log-interval', type=int, default=100, help='Number of steps between reporting training stats')
+    parser.add_argument('--eval-interval', type=int, default=1000, help='Number of steps between calculating and logging validation performance')
+    parser.add_argument('--log-wandb', action='store_true', default=False, help='Whether to log validation performance using W&B')
+
+    # Data parameters
+    parser.add_argument('--num-epochs', type=int, default=50)
+    parser.add_argument('--batch-size', type=int, default=512)
+    parser.add_argument('--num-workers', type=int, default=0)
+    parser.add_argument('--pin-memory', action='store_true', default=False)
+
+    # Model and optimizer parameters
+    parser.add_argument('--learning-rate', type=float, default=2e-05)
+    parser.add_argument('--warmup-steps', type=int, default=0)
+    parser.add_argument('--dropout', type=float, default=0.0, help='Classifier dropout rate. Does not affect encoder.')
+    parser.add_argument('--max-len', type=int, default=128, help='Max. number of characters for input')
+    parser.add_argument('--decoder-dim-feedforward', type=int, default=None, help='Defaults to endoder hidden dim if not specified.')
+
+    # Augmentation
+    parser.add_argument('--num-transformations', type=int, default=3)
+    parser.add_argument('--augmentation-prob', type=float, default=0.3)
+    parser.add_argument('--unk-lang-prob', type=float, default=0.25)
+
+    args = parser.parse_args()
+
+    if args.log_wandb and not has_wandb:
+        raise ImportError('Specified --log-wandb, but wandb is not installed')
+
+    # TODO add checks on file paths and directories
+
+    return args
+
+
+def setup_datasets(
+        args: argparse.Namespace,
+        formatter: BlockyHISCOFormatter,
+        tokenizer: CanineTokenizer,
+) -> tuple[OccDatasetV2InMemMultipleFiles, OccDatasetV2InMemMultipleFiles]:
+    dataset_train = OccDatasetV2InMemMultipleFiles(
+        fnames_data=args.train_data,
+        formatter=formatter,
+        tokenizer=tokenizer,
+        max_input_len=args.max_len,
+        training=True,
+        alt_prob=args.augmentation_prob,
+        n_trans=args.num_transformations,
+        unk_lang_prob=args.unk_lang_prob,
+    )
+
+    dataset_val = OccDatasetV2InMemMultipleFiles(
+        fnames_data=args.val_data,
+        formatter=formatter,
+        tokenizer=tokenizer,
+        max_input_len=args.max_len,
+        training=False,
+    )
+
+    return dataset_train, dataset_val
+
+
+def load_states(
+        save_dir: str,
+        model: Seq2SeqOccCANINE,
+        optimizer: torch.optim.Optimizer,
+        scheduler: torch.optim.lr_scheduler.LRScheduler,
+        initial_checkpoint: str | None = None,
+) -> int:
+    if 'last.bin' in os.listdir(save_dir):
+        print(f'Model states exist at {save_dir}. Resuming from last.bin')
+
+        states = torch.load(os.path.join(save_dir, 'last.bin'))
+
+        model.load_state_dict(states['model'])
+        optimizer.load_state_dict(states['optimizer'])
+        scheduler.load_state_dict(states['scheduler'])
+
+        current_step = states['step']
+
+        return current_step
+
+    if initial_checkpoint is None:
+        return 0
+
+    if initial_checkpoint.lower() == 'occ-canine-v1':
+        print('Initializing encoder from HF (christianvedel/OccCANINE)')
+        encoder = CANINEOccupationClassifier_hub.from_pretrained("christianvedel/OccCANINE")
+        model.encoder.load_state_dict(encoder.basemodel.state_dict())
+        # TODO check encoder is properly garbage collected
+
+        return 0
+
+    print(f'Initializing model from {initial_checkpoint}')
+    states = torch.load(initial_checkpoint)
+    model.load_state_dict(states['model'])
+
+    return 0
+
+
+def main():
+    args = parse_args()
+
+    if args.log_wandb:
+        wandb_init(
+            output_dir=args.save_dir,
+            project='histco-v2',
+            name=os.path.basename(args.save_dir),
+            resume='auto',
+            config=args,
+        )
+
+    # Target-side tokenization
+    formatter = blocky5()
+
+    # Input-side tokenization
+    tokenizer = load_tokenizer(
+        model_domain='Multilingual_CANINE',
+    )
+
+    # Datasets
+    dataset_train, dataset_val = setup_datasets(
+        args=args,
+        formatter=formatter,
+        tokenizer=tokenizer,
+    )
+
+    # Data loaders
+    data_loader_train = DataLoader(
+        dataset_train,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+        )
+    data_loader_val = DataLoader(
+        dataset_val,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+        )
+
+    # Setup model, optimizer, scheduler
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    model = Seq2SeqOccCANINE(
+        model_domain='Multilingual_CANINE', # TODO make arg, discuss with Vedel
+        num_classes=formatter.num_classes,
+        dropout_rate=args.dropout,
+        decoder_dim_feedforward=args.decoder_dim_feedforward,
+    ).to(device)
+
+    optimizer = AdamW(model.parameters(), lr=args.learning_rate)
+    total_steps = len(data_loader_train) * args.num_epochs
+    scheduler = get_linear_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=args.warmup_steps,
+        num_training_steps=total_steps,
+    )
+
+    loss_fn = BlockOrderInvariantLoss(
+        pad_idx=PAD_IDX,
+        nb_blocks=5,
+        block_size=5,
+    ).to(device)
+
+    current_step = load_states(
+        save_dir=args.save_dir,
+        model=model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        initial_checkpoint=args.initial_checkpoint,
+    )
+
+    # Save arguments
+    with open(os.path.join(args.save_dir, 'args.yaml'), 'w', encoding='utf-8') as args_file:
+        args_file.write(
+            yaml.safe_dump(args.__dict__, default_flow_style=False)
+        )
+
+    train(
+        model=model,
+        data_loaders={
+            'data_loader_train': data_loader_train,
+            'data_loader_val': data_loader_val,
+        },
+        loss_fn=loss_fn,
+        optimizer=optimizer,
+        device=device,
+        scheduler=scheduler,
+        save_dir=args.save_dir,
+        total_steps=total_steps,
+        current_step=current_step,
+        log_interval=args.log_interval,
+        eval_interval=args.eval_interval,
+        save_interval=args.save_interval,
+        log_wandb=args.log_wandb,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/train_v2.py
+++ b/train_v2.py
@@ -26,6 +26,7 @@ from histocc import (
     load_tokenizer,
     Seq2SeqOccCANINE,
     BlockOrderInvariantLoss,
+    CANINEOccupationClassifier_hub,
 )
 from histocc.seq2seq_engine import train
 from histocc.formatter import (
@@ -34,8 +35,6 @@ from histocc.formatter import (
     PAD_IDX,
 )
 from histocc.utils import wandb_init
-
-from histocc.model_assets import CANINEOccupationClassifier_hub
 
 try:
     # want to do import to set has_wandb even if not used directly


### PR DESCRIPTION
PR adds entrypoint and CLI for training of seq2seq-style models. Further, command lines to reproduce results added.

Note that this new entrypoint is called `train_v2.py` to not remove the old entrypoint. We could also repurpose the old name, or we could call this new one `train_seq2seq.py` to indicate it's for seq2seq-style models (and not for our proposed mixer models, which will need a new entrypoint).