### PR TITLE
Confidence fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,4 @@ test_wrapper.py
 test_wrappers.py
 
 tmp.py
+misc.py

--- a/histocc/prediction_assets.py
+++ b/histocc/prediction_assets.py
@@ -650,10 +650,10 @@ class OccCANINE:
                 max_len = data_loader.dataset.formatter.max_seq_len,
                 start_symbol = BOS_IDX,
                 )
-            
+
             outputs_s2s = outputs[0].cpu().numpy()
             probs_s2s = outputs[1].cpu().numpy()
-            
+
             # Compute order invariant confidence
             if order_invariant_conf:
                 # Location of multiple labels
@@ -661,8 +661,8 @@ class OccCANINE:
                     data_loader.dataset.formatter.clean_pred,
                     outputs[0].cpu().numpy(),
                 ))
-                
-                # Generate list of codes 
+
+                # Generate list of codes
                 codes_lists = [self._output_permutations(i) for i in outputs_mapped_to_label]
 
                 order_inv_probs_batch = [float(0) for i in range(len(outputs_s2s))]
@@ -687,7 +687,7 @@ class OccCANINE:
                             codes_list = codes_list_encoded,
                             start_symbol = BOS_IDX,
                         )
-                        # Test 
+                        # Test
                         if outputs_order_inv.shape[1] != len_list:
                             raise ValueError(f"outputs_order_inv.shape[1] != len_list: {outputs_order_inv.shape[1]} != {len_list}")
 
@@ -721,7 +721,7 @@ class OccCANINE:
         ))
 
         if order_invariant_conf:
-        
+
             preds = pd.DataFrame({
                 'input': inputs,
                 'pred_s2s': preds_s2s,
@@ -810,7 +810,7 @@ class OccCANINE:
         out_type = 'probs'
 
         return results, out_type, inputs
-    
+
     def _output_permutations(self, output):
         """
         This function takes an output from the model with multiple labels
@@ -864,7 +864,7 @@ class OccCANINE:
             if behavior == "good":
                 prediction_type = "greedy"
 
-            if self.verbose: 
+            if self.verbose:
                 print(f"Based on behavior = '{behavior}', prediction_type was automatically set to '{prediction_type}'")
 
         # Validate 'prediction_type'
@@ -1035,7 +1035,7 @@ class OccCANINE:
         - inputs (list): The original occupational strings used for prediction.
         - threshold (float): threshold to use (only relevant if out_type == "probs")
         - k_pred (int): Maximum number of predicted occupational codes to keep
-        - order_invariant_conf (bool): If True an order invariant confidence is computed. 
+        - order_invariant_conf (bool): If True an order invariant confidence is computed.
 
         Returns:
         - Depends on the 'what' parameter.
@@ -1126,7 +1126,7 @@ class OccCANINE:
                         for sub_item in item:
                             if sub_item in inv_key:
                                 res_bin[i, inv_key[sub_item]] = 1
-                    
+
                     res = res_bin
                     res = pd.DataFrame(res, columns=[f"{self.system}_{self.key[i]}" for i in range(len(self.key))])
 
@@ -1170,7 +1170,7 @@ class OccCANINE:
                     res.insert(0, 'occ1', out.input)
 
                 return res
-            
+
             else:
                 raise ValueError(f"'what' ('{what}') did not match any output for 'out_type' ('{out_type}')")
 

--- a/histocc/prediction_assets.py
+++ b/histocc/prediction_assets.py
@@ -630,7 +630,7 @@ class OccCANINE:
             decoder = greedy_decode
             decoder_full = full_search_decoder_seq2seq_optimized # Used in order invariant confidence
         else:
-            raise TypeError(f"model_type: '{self.model_type}' does not work with the greedy prediciton")
+            raise TypeError(f"model_type: '{self.model_type}' does not work with the greedy prediction")
 
         # Setup
         verbose = self.verbose

--- a/histocc/prediction_assets.py
+++ b/histocc/prediction_assets.py
@@ -307,7 +307,7 @@ class OccCANINE:
 
         return key, key_desc
 
-    def _list_of_formatted_codes(self, codes_list = None):
+    def _list_of_formatted_codes(self, codes_list: list[str] | None = None):
         """
         Returns a list of formatted codes. According to the seq2seq formatter
         """

--- a/tests/test_order_inv_conf.py
+++ b/tests/test_order_inv_conf.py
@@ -1,0 +1,32 @@
+import unittest
+
+from histocc import OccCANINE, DATASETS
+
+
+class AbstractTestWrapperOccCANINE(unittest.TestCase):
+    def setUp(self):
+        self.toydata = DATASETS['toydata']()
+        self.model = OccCANINE()
+
+    def test_probs_higher(self):
+        ''' Test estimated probabilities through order invariant confidence is
+        strictly higher than if we use naive approach in cases with multiple
+        predicted codes (and equal otherwise).
+        '''
+        probs_order_inv = self.model.predict(
+            self.toydata['occ1'], order_invariant_conf=True
+        )
+        probs_naive = self.model.predict(self.toydata['occ1'], order_invariant_conf=False)
+
+        diff = probs_order_inv['conf'] - probs_naive['conf']
+        multiple_predicted_codes = probs_order_inv['hisco_2'] != 'nan'
+
+        # If multiple predicted codes, probabilities should be higher
+        self.assertTrue((diff[multiple_predicted_codes] > 0).all())
+
+        # If not multiple codes, probabilities should be identical
+        self.assertAlmostEqual(diff[~multiple_predicted_codes].abs().sum(), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduced an order invariant version of confidence scores, which conceptually matches the order invariant loss the model is trained on. 

This works by first running the ordinary prediction and then, for each case with >1 predicted label, rerunning on all permutations to get a confidence estimate of each. The sum of these is the order invariant confidence. 

E.g. if the output is 61110&71100 then we obtain the estimated prob of both 61110&71100 and 71100 &61110 and add these up. 